### PR TITLE
Retry count no longer added to test display name. This is so that we …

### DIFF
--- a/docs/AttributeEx/RetryAttribute.md
+++ b/docs/AttributeEx/RetryAttribute.md
@@ -2,7 +2,7 @@
 - The __RetryAttribute__ is used on a test method to specify that it should be rerun if it fails, up to a maximum number of times.
 - Only tests with an outcome of "Failed", can trigger a retry. For the complete set of possible test outcomes see [here](https://github.com/Microsoft/testfx/blob/master/src/TestFramework/MSTest.Core/UnitTestOutcome.cs).
 - A test method can be retried up to a maximum of 10 times (the input argument representing the retry count will be automatically sanitized to be within the range 1 to 10).
-- Each execution attempt is recorded as a child test. The execution attempt number is appended to the test method's display name.
+- Each execution attempt is recorded as a child test.
 - In the case of data driven tests only those invocations of the test method that failed are subject to retry. For retries of data driven tests, the execution attempt number is not shown as part of the test method's display name.
 
 ## Arguments

--- a/src/MSTest.TestFramework.Extensions/TestMethodEx/TestMethodExAttribute.cs
+++ b/src/MSTest.TestFramework.Extensions/TestMethodEx/TestMethodExAttribute.cs
@@ -48,20 +48,14 @@ namespace MSTest.TestFramework.Extensions.TestMethodEx
             for (int count = 0; count < retryCount; count++)
             {
                 var testResults = base.Execute(testMethod);
+                res.AddRange(testResults);
 
                 if (testResults.Any((tr) => tr.Outcome == UnitTestOutcome.Failed))
                 {
-                    foreach (var testResult in testResults)
-                    {
-                        testResult.DisplayName = $"{testMethod.TestMethodName} - Execution attempt {count + 1}";
-                        res.AddRange(testResults);
-                    }
+                    continue;
                 }
-                else
-                {
-                    res.AddRange(testResults);
-                    break;
-                }
+
+                break;
             }
 
             return res.ToArray();


### PR DESCRIPTION
…are consistent with how all other attributes are treated.