### PR TITLE
Feature Update for RetryAttribute - Add the possibility to consider only the last test run result on Retry Attribute 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,8 @@ Contribute to the [documentation](./docs).
 ### MSTest Test Framework
 The MSTestEx solution already contains a NuGet reference to the MSTest Test Framework v2.2.8.
 
-### .NET Core
-Install DotNet Core from here: [.NET Core 5.0](https://dotnet.microsoft.com/download/dotnet/5.0)
+### .NET 6.0
+Install DotNet from here: [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0)
 
 ## Building MSTestEx
 Run the following commands to build MSTestEx

--- a/docs/AttributeEx/RetryAttribute.md
+++ b/docs/AttributeEx/RetryAttribute.md
@@ -3,11 +3,16 @@
 - Only tests with an outcome of "Failed", can trigger a retry. For the complete set of possible test outcomes see [here](https://github.com/Microsoft/testfx/blob/master/src/TestFramework/MSTest.Core/UnitTestOutcome.cs).
 - A test method can be retried up to a maximum of 10 times (the input argument representing the retry count will be automatically sanitized to be within the range 1 to 10).
 - Each execution attempt is recorded as a child test.
-- If a test method is rerun (because if failed), and passes in subsequently, the overall result is still reported as failed.
+- If a test method is rerun due to failure and passes on a subsequent run, the overall result will be reported based on the `finalAttemptResultOnly` flag:
+  - If `finalAttemptResultOnly` is set to **`true`**, only the result of the last retry attempt is considered, meaning the final result could be **Passed** if the last retry passed.
+  - If `finalAttemptResultOnly` is set to **`false`**, the overall result will be reported as **Failed**.
+
 - In the case of data driven tests only those invocations of the test method that failed are subject to retry. For retries of data driven tests, the execution attempt number is not shown as part of the test method's display name.
 
 ## Arguments
-input - int representing the retry count.
+- __retryCount__: An integer representing the number of retries (minimum of 1, maximum of 10).
+- __finalAttemptResultOnly__ (optional, default `false`): A boolean value indicating whether only the result from the last retry attempt should be considered as the overall test result.
+
 
 ## Usage
 - add a NuGet reference to the MSTestEx package.
@@ -24,7 +29,7 @@ namespace UnitTestProject1
     public class UnitTest1
     {
         [TestMethodEx]
-        [Retry(5)]
+        [Retry(5, true)]
         public void TestMethod1()
         {
             // Test logic that causes the test to fail.
@@ -34,7 +39,7 @@ namespace UnitTestProject1
 ```
 
 ## Applies to
-MSTestEx v1.0.2
+MSTestEx v1.0.3
 
 ## Notes
  - Note that any surrounding TestInitialize and TestCleanup methods will be executed only once.

--- a/nuspecs/MSTestEx.nuspec
+++ b/nuspecs/MSTestEx.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>MSTestEx</id>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <authors>pvlakshm</authors>
     <owners>pvlakshm</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/MSTest.TestFramework.Extensions/AttributeEx/RetryAttribute.cs
+++ b/src/MSTest.TestFramework.Extensions/AttributeEx/RetryAttribute.cs
@@ -11,7 +11,8 @@ namespace MSTest.TestFramework.Extensions.AttributeEx
         private const int MAX_RETRY_COUNT = 10;
 
         public RetryAttribute(
-            int retryCount)
+            int retryCount,
+            bool retryOnFail = false)
         {
             if (retryCount < MIN_RETRY_COUNT || MAX_RETRY_COUNT < retryCount)
             {
@@ -19,8 +20,11 @@ namespace MSTest.TestFramework.Extensions.AttributeEx
             }
 
             Value = retryCount;
+            RetryOnFail = retryOnFail;
         }
 
         public int Value { get; }
+
+        public bool RetryOnFail { get; }
     }
 }

--- a/src/MSTest.TestFramework.Extensions/AttributeEx/RetryAttribute.cs
+++ b/src/MSTest.TestFramework.Extensions/AttributeEx/RetryAttribute.cs
@@ -4,6 +4,7 @@ namespace MSTest.TestFramework.Extensions.AttributeEx
 {
     /// <summary>- The RetryAttribute is used on a test method to specify that it should be rerun if it fails, up to a maximum number of times.</summary>
     /// <param name="retryCount">int representing the retry count.</param>"
+    /// <param name="finalAttemptResultOnly">boolean value ensures that only the final test result (from the last retry attempt) is considered as the test's overall result.</param>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class RetryAttribute : Attribute
     {
@@ -12,7 +13,7 @@ namespace MSTest.TestFramework.Extensions.AttributeEx
 
         public RetryAttribute(
             int retryCount,
-            bool retryOnFail = false)
+            bool finalAttemptResultOnly = false)
         {
             if (retryCount < MIN_RETRY_COUNT || MAX_RETRY_COUNT < retryCount)
             {
@@ -20,11 +21,11 @@ namespace MSTest.TestFramework.Extensions.AttributeEx
             }
 
             Value = retryCount;
-            RetryOnFail = retryOnFail;
+            FinalAttemptResultOnly = finalAttemptResultOnly;
         }
 
         public int Value { get; }
 
-        public bool RetryOnFail { get; }
+        public bool FinalAttemptResultOnly { get; }
     }
 }

--- a/src/MSTest.TestFramework.Extensions/MSTest.TestFramework.Extensions.csproj
+++ b/src/MSTest.TestFramework.Extensions/MSTest.TestFramework.Extensions.csproj
@@ -1,11 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<Version>1.0.5</Version>
+	</PropertyGroup>
 
 </Project>

--- a/src/MSTest.TestFramework.Extensions/TestMethodEx/TestMethodExAttribute.cs
+++ b/src/MSTest.TestFramework.Extensions/TestMethodEx/TestMethodExAttribute.cs
@@ -75,7 +75,7 @@ namespace MSTest.TestFramework.Extensions.TestMethodEx
             int repeatCount = 1;
             bool finalAttemptResultOnly = false;
 
-            Attribute[] attr = testMethod.GetAllAttributes(false);
+            Attribute[] attr = testMethod.GetAllAttributes(false) ?? Array.Empty<Attribute>();
 
             var retryAttr = attr.OfType<RetryAttribute>().FirstOrDefault();
             if (retryAttr != null)

--- a/test/MSTest.TestFramework.ExtensionsTests/MSTest.TestFramework.ExtensionsTests.csproj
+++ b/test/MSTest.TestFramework.ExtensionsTests/MSTest.TestFramework.ExtensionsTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Feature Update: RetryAttribute

This pull request introduces an enhancement to the RetryAttribute feature, allowing greater flexibility in handling test retries. The following key changes have been implemented:

Final Attempt Result Option (finalAttemptResultOnly):

New Feature: Introduced a new optional argument, finalAttemptResultOnly, to control how the overall result of the test is reported. If this flag is set to true, only the result of the final retry attempt is considered for the overall result.
Default Behavior: By default, this flag is false, meaning the test will be marked as "Failed" even if it passes on a retry, unless finalAttemptResultOnly is explicitly set to true.

Arguments:

finalAttemptResultOnly: Boolean (optional, default false). Determines if only the result of the last retry attempt should be considered for the overall test result.

This enhancement introduces the finalAttemptResultOnly flag to give users more flexibility in how test results are reported after retries, offering control over the final test outcome.

Updated also .NET version to 6.0.